### PR TITLE
Fix search functionality.

### DIFF
--- a/app/controllers/sidebar.js
+++ b/app/controllers/sidebar.js
@@ -17,7 +17,7 @@ var SidebarController = Ember.ObjectController.extend({
     }
 
     Ember.run.debounce(this, function(){
-      this.set('searchResults', apiStore.search(query));
+      apiStore.search(query);
     }, 50);
 
   }.observes('query')

--- a/app/models/api_store.js
+++ b/app/models/api_store.js
@@ -168,7 +168,8 @@ var ApiStore = Ember.Object.extend({
   },
 
   search: function(query) {
-    var parsedQuery, compiledQuery, result, index, promises;
+    var self = this,
+        parsedQuery, compiledQuery, result, index, promises;
 
     result = {};
 
@@ -190,6 +191,8 @@ var ApiStore = Ember.Object.extend({
       result.modules    = filter(results.modules, results.data.modules, compiledQuery.modules   ).slice(0,10);
       result.classes    = filter(results.classes, results.data.classes, compiledQuery.classes   ).slice(0,10);
       result.classItems = filterClassItems(classitems,  compiledQuery.classitems).slice(0,30);
+
+      self.set('searchResults', result);
 
       return result;
     });

--- a/tests/unit/models/api_store_test.js
+++ b/tests/unit/models/api_store_test.js
@@ -140,6 +140,18 @@ module("Unit - ApiStore - Search", {
   }
 });
 
+test('search sets searchResults upon fulfillment', function(){
+  expect(1);
+
+  function assertions(results){
+    deepEqual(results, apiStore.get('searchResults'));
+  }
+
+  Ember.run(function(){
+    apiStore.search('Ember').then(assertions);
+  });
+});
+
 test('search returns a valid search result object', function(){
   expect(5);
 


### PR DESCRIPTION
apiStore.search('blah') returns a promise, and at this point templates
are not promise aware. This change also makes apiStore.search set
searchResults which can be bound to in the template.
