### PR TITLE
Allow the dataUrl to be specified in query params.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -14,7 +14,7 @@ var App = Ember.Application.extend({
 App.initializer({
   name: 'injections',
   initialize: function(container, application) {
-    application.register('api-store:main', ApiStore.create({ dataUrl: '/api/api.json' }), { instantiate: false });
+    application.register('api-store:main', ApiStore.create({ dataUrl: application.get('apiDataUrl')}), { instantiate: false });
     application.inject('controller', 'apiStore', 'api-store:main');
     application.inject('component:api-class-link', 'apiStore', 'api-store:main');
     application.inject('route', 'apiStore', 'api-store:main');

--- a/public/index.html
+++ b/public/index.html
@@ -70,7 +70,16 @@
   </div>
   -->
   <script>
-    window.App = require('appkit/app').create({apiDataUrl: '/api/api.json'});
+    function getURLParameterByName(n){
+      var half = location.search.split(n+'=')[1];
+      return half ? decodeURIComponent(half.split('&')[0]) : null;
+    };
+
+    var dataUrl = getURLParameterByName('dataUrl');
+
+    if (!dataUrl) { dataUrl = '/api/api.json' }
+
+    window.App = require('appkit/app').create({apiDataUrl: dataUrl});
   </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -70,7 +70,7 @@
   </div>
   -->
   <script>
-    window.App = require('appkit/app').create();
+    window.App = require('appkit/app').create({apiDataUrl: '/api/api.json'});
   </script>
 </body>
 </html>


### PR DESCRIPTION
Note: this does not use the new query-params feature of Ember, it is simply
using the normal javascript query param parsing so that when the
application is booted, we pass it the correct dataUrl.

So navigating to the site with a url like:

/?dataUrl=/tests/support/api.json

Will do an XHR and use `/tests/support/api.json` for its data source.

This resolves #3, but that may need to be revisited when query-params support is
available in a stable version.
